### PR TITLE
add implementation for multi display

### DIFF
--- a/config.cpp
+++ b/config.cpp
@@ -7,7 +7,7 @@
 Config::Config() :
     simulationFPS(60.0f), gravity(9.8f),
     defaultModelPosition(0.0f, 0.0f), defaultScale(1.0f),
-    defaultCameraPosition(0, 10, 50), defaultGazePosition(0, 10, 0)
+    defaultCameraPosition(0, 10, 50), defaultGazePosition(0, 10, 0),defaultDisplayIndex(0)
 {}
 
 Config Config::Parse(const std::filesystem::path& configFile) {
@@ -70,6 +70,8 @@ Config Config::Parse(const std::filesystem::path& configFile) {
         config.simulationFPS = toml::find_or(
                 entire, "simulation-fps", config.simulationFPS);
         config.gravity = toml::find_or(entire, "gravity", config.gravity);
+        config.defaultDisplayIndex = toml::find_or(
+                entire, "default-display-index", config.defaultDisplayIndex);
     } catch (std::runtime_error& e) {
         // File open error, file read error, etc...
         Err::Exit(e.what());

--- a/main_windows.cpp
+++ b/main_windows.cpp
@@ -197,7 +197,7 @@ void AppMain::createWindow() {
         WS_EX_NOREDIRECTIONBITMAP |
         WS_EX_NOACTIVATE |
         WS_EX_TOPMOST |
-        WS_EX_LAYERED |  // TODO: Is there another way?
+        WS_EX_LAYERED |
         WS_EX_TRANSPARENT;
 
     const HINSTANCE hInstance = GetModuleHandleW(nullptr);
@@ -206,9 +206,20 @@ void AppMain::createWindow() {
         Err::Log("Failed to load application icon.");
     }
 
-    RECT rect = {};
-    SystemParametersInfoW(SPI_GETWORKAREA, 0, &rect, 0);
+    Config config = Config::Parse("config.toml");
+    int targetDisplayIndex = config.defaultDisplayIndex;
 
+    DISPLAY_DEVICE displayDevice;
+    displayDevice.cb = sizeof(DISPLAY_DEVICE);
+    EnumDisplayDevices(NULL, targetDisplayIndex, &displayDevice, 0);
+
+    DEVMODE dm;
+    dm.dmSize = sizeof(DEVMODE);
+    EnumDisplaySettings(displayDevice.DeviceName, ENUM_CURRENT_SETTINGS, &dm);
+
+    RECT rect = {dm.dmPosition.x, dm.dmPosition.y,
+        dm.dmPosition.x + dm.dmPelsWidth,
+        dm.dmPosition.y + dm.dmPelsHeight};
 
     WNDCLASSEXW wc = {};
 
@@ -398,6 +409,7 @@ DWORD WINAPI AppMain::showMenu(LPVOID param) {
         Err::Log("Failed to create dummy window for menu.");
         return 1;
     }
+
 
     POINT point;
     if (!GetCursorPos(&point)) {

--- a/yommd.hpp
+++ b/yommd.hpp
@@ -133,6 +133,7 @@ struct Config {
     float defaultScale;
     glm::vec3 defaultCameraPosition;
     glm::vec3 defaultGazePosition;
+    int defaultDisplayIndex;
 
     static Config Parse(const std::filesystem::path& configFile);
 };


### PR DESCRIPTION
tomlで出力先ディスプレイを選択できるようにしました。

```
model = "awesome_model.pmx"
gravity = 9.8
default-model-position = [0.65, 0.85]
default-camera-position = [0.0, 20.0, 50.0]
default-scale = 0.7
default-display-index = 2


```

windowsのディスプレイの設定で拡大と縮小を100%以外にしているとモデルが他のディスプレイに表示されたり、画面外にモデルが出て行ってしまうことがあります。[ここらへん](https://zenn.dev/tenka/articles/windows_display_monitor_dpi)で修正できるかもしれない。
