### PR TITLE
ci: Fix build failure

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "lib/saba"]
 	path = lib/saba
-	url = https://github.com/benikabocha/saba
+	url = https://github.com/mityu/saba
+	branch = cmake-min-req
 [submodule "lib/glm"]
 	path = lib/glm
 	url = https://github.com/g-truc/glm


### PR DESCRIPTION
The official repository saba library now isn't able to build with CMake >= 4.0.  Therefore, as the temporal fix, use the forked one with fix for the build failure instead.